### PR TITLE
Upgrade lxml to 6.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "lxml==5.4.0",
+    "lxml==6.1.0",
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lxml==5.4.0
+lxml==6.1.0
 generateDS==2.44.3


### PR DESCRIPTION
Compilation of 5.4.0 fails with libxml2 >= 2.15.0. [1]

The primary breaking change in major version 6.0.0 appears to have been dropping support for Python < 3.8. [2]

[1] https://bugs.launchpad.net/lxml/+bug/2125278
[2] https://pypi.org/project/lxml/6.0.0/